### PR TITLE
Retaining matrix structure

### DIFF
--- a/R/survival_tidiers.R
+++ b/R/survival_tidiers.R
@@ -231,7 +231,7 @@ tidy.coxph <- function(x, exponentiate = FALSE, conf.int = .95, ...) {
     co <- coef(s)
 
     nn <- c("estimate", "std.error", "statistic", "p.value")
-    ret <- fix_data_frame(co[, -2], nn)
+    ret <- fix_data_frame(co[, -2, drop=FALSE], nn)
     
     if (exponentiate) {
         ret$estimate <- exp(ret$estimate)


### PR DESCRIPTION
When you drop the exponentiated column from a one-row matrix (ie, a Cox model with only 1 continuous or binary independent variable), the object returned is a numeric vector, and `fix_data_frame` can't figure out what to do with it.  Adding the `drop=FALSE` argument keeps the matrix in tact.