### PR TITLE
broom::tidy(car::Anova(...)) returns mismatched columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: broom
 Type: Package
 Title: Convert Statistical Analysis Objects into Tidy Data Frames
-Version: 0.3.7
+Version: 0.3.7.9000
 Date: 2015-05-05
 Authors@R: c(
     person("David", "Robinson", email = "admiral.david@gmail.com", role = c("aut", "cre")),

--- a/R/anova_tidiers.R
+++ b/R/anova_tidiers.R
@@ -50,7 +50,7 @@ tidy.anova <- function(x, ...) {
     # x is car::Anova
       nn <- c("sumsq", "df", "statistic", "p.value")
     }
-    if (is.na(nn)) {
+    if (identical(nn, NA)) {
        stop("Unrecognized column names in anova object")
     }
     ret <- fix_data_frame(x, nn[1:ncol(x)])

--- a/R/anova_tidiers.R
+++ b/R/anova_tidiers.R
@@ -42,7 +42,17 @@ NULL
 #' 
 #' @export
 tidy.anova <- function(x, ...) {
-    nn <- c("df", "sumsq", "meansq", "statistic", "p.value")
+    # x is stats::anova
+    nn <- NA
+    if (identical(colnames(x), c("Df", "Sum Sq", "Mean Sq", "F value", "Pr(>F)"))) {
+      nn <- c("df", "sumsq", "meansq", "statistic", "p.value")
+    } else if (identical(colnames(x), c("Sum Sq", "Df", "F value", "Pr(>F)"))) {
+    # x is car::Anova
+      nn <- c("sumsq", "df", "statistic", "p.value")
+    }
+    if (is.na(nn)) {
+       stop("Unrecognized column names in anova object")
+    }
     ret <- fix_data_frame(x, nn[1:ncol(x)])
 
     if ("term" %in% colnames(ret)) {


### PR DESCRIPTION
Currently `broom::tidy` applied to an `anova` object as returned by the `car::Anova` function will give a wrong data frame with an unclear warning message:

```
Warning message:
In colnames(ret)[-1] <- newnames :
  number of items to replace is not a multiple of replacement length
```

The returned column names will be mismatched, as `car::Anova` returns columns in a different order than `stats::anova` and does not return the "Mean Sq" column.

This commit adds a check for the column names before tidying the `anova` object, preventing and fixing those column mismatches.

It is a pity that both packages are not compatible and use the same object name "anova", but I feel this is the best approach to tidy both of them.

Comments and suggestions are welcome.

Thanks for your time and work with this package