### PR TITLE
Reproducible research encourages devel. versioning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: broom
 Type: Package
 Title: Convert Statistical Analysis Objects into Tidy Data Frames
-Version: 0.3.7
+Version: 0.3.7.9000
 Date: 2015-05-05
 Authors@R: c(
     person("David", "Robinson", email = "admiral.david@gmail.com", role = c("aut", "cre")),


### PR DESCRIPTION
`sessionInfo()` will report `0.3.7` even if I have installed the development version of broom. This is bad for reproducible research and packages and scripts depending on the development version of broom.

See http://r-pkgs.had.co.nz/description.html#version

This commit bumps the version to 0.3.7.9000, so sessionInfo() will report a version number easily identifiable as "development".

Feel free to reject this commit if you don't like this versioning scheme, personally I find it very useful and simple to apply.

Thanks for your time and efforts in this package