### PR TITLE
fix warning in tidy.anova

### DIFF
--- a/R/anova_tidiers.R
+++ b/R/anova_tidiers.R
@@ -59,7 +59,7 @@ tidy.anova <- function(x, ...) {
     names(renamers) <- make.names(names(renamers))
     
     x <- fix_data_frame(x)
-    unknown_cols <- setdiff(colnames(x), names(renamers))
+    unknown_cols <- setdiff(colnames(x), c("term", names(renamers)))
     if (length(unknown_cols) > 0) {
         warning("The following column names in ANOVA output were not",
                 "recognized or transformed: ",

--- a/R/anova_tidiers.R
+++ b/R/anova_tidiers.R
@@ -61,7 +61,7 @@ tidy.anova <- function(x, ...) {
     x <- fix_data_frame(x)
     unknown_cols <- setdiff(colnames(x), c("term", names(renamers)))
     if (length(unknown_cols) > 0) {
-        warning("The following column names in ANOVA output were not",
+        warning("The following column names in ANOVA output were not ",
                 "recognized or transformed: ",
                 paste(unknown_cols, collapse = ", "))
     }


### PR DESCRIPTION
Hi,

the column `term` in `tidy.anova` should be ignored in the respective `warning` call.

Best, Sven