### PR TITLE
Return proper test statistic label in `tidy.manova` output

### DIFF
--- a/R/stats_tidiers.R
+++ b/R/stats_tidiers.R
@@ -132,14 +132,20 @@ tidy.TukeyHSD <- function(x, ...) {
 #' containing the information from \link{summary.manova}.
 #' 
 #' @param x object of class "manova"
-#' @param ... additional arguments passed on to \code{summary.manova},
-#' such as \code{test}
+#' @param test one of "Pillai" (Pillai's trace), "Wilks" (Wilk's lambda), "Hotelling-Lawley" (Hotelling-Lawley trace) or "Roy" (Roy's greatest root) indicating which test statistic should be used. Defaults to "Pillai"
+#' @param ... additional arguments passed on to \code{summary.manova}
 #' 
 #' @return A data.frame with the columns
 #'     \item{term}{Term in design}
 #'     \item{statistic}{Approximate F statistic}
 #'     \item{num.df}{Degrees of freedom}
 #'     \item{p.value}{P-value}
+#'     
+#' Depending on which test statistic is specified, one of the following columns is also included:
+#'     \item{pillai}{Pillai's trace}
+#'     \item{wilks}{Wilk's lambda}
+#'     \item{hl}{Hotelling-Lawley trace}
+#'     \item{roy}{Roy's greatest root}
 #' 
 #' @examples
 #' 
@@ -149,9 +155,15 @@ tidy.TukeyHSD <- function(x, ...) {
 #' @seealso \code{\link{summary.manova}}
 #' 
 #' @export
-tidy.manova <- function(x, ...) {
-    nn <-  c("df", "pillai", "statistic", "num.df", "den.df", "p.value")
-    ret <- fix_data_frame(summary(x, ...)$stats, nn)
+tidy.manova <- function(x, test = "Pillai", ...) {
+    # match test name (default to 'pillai')
+    # partially match the name so we're consistent with the underlying function
+    test.pos <- pmatch(test, c("Pillai", "Wilks",
+        "Hotelling-Lawley", "Roy"))
+    test.name <- c("pillai", "wilks", "hl", "roy")[test.pos]
+    
+    nn <-  c("df", test.name, "statistic", "num.df", "den.df", "p.value")
+    ret <- fix_data_frame(summary(x, test = test, ...)$stats, nn)
     # remove residuals row (doesn't have useful information)
     ret <- ret[-nrow(ret), ]
     ret

--- a/man/tidy.manova.Rd
+++ b/man/tidy.manova.Rd
@@ -4,13 +4,14 @@
 \alias{tidy.manova}
 \title{tidy a MANOVA object}
 \usage{
-\method{tidy}{manova}(x, ...)
+\method{tidy}{manova}(x, test = "Pillai", ...)
 }
 \arguments{
 \item{x}{object of class "manova"}
 
-\item{...}{additional arguments passed on to \code{summary.manova},
-such as \code{test}}
+\item{test}{one of "Pillai" (Pillai's trace), "Wilks" (Wilk's lambda), "Hotelling-Lawley" (Hotelling-Lawley trace) or "Roy" (Roy's greatest root) indicating which test statistic should be used. Defaults to "Pillai"}
+
+\item{...}{additional arguments passed on to \code{summary.manova}}
 }
 \value{
 A data.frame with the columns
@@ -18,6 +19,12 @@ A data.frame with the columns
     \item{statistic}{Approximate F statistic}
     \item{num.df}{Degrees of freedom}
     \item{p.value}{P-value}
+
+Depending on which test statistic is specified, one of the following columns is also included:
+    \item{pillai}{Pillai's trace}
+    \item{wilks}{Wilk's lambda}
+    \item{hl}{Hotelling-Lawley trace}
+    \item{roy}{Roy's greatest root}
 }
 \description{
 Constructs a data frame with one row for each of the terms in the model,


### PR DESCRIPTION
Fixes #80.

Prior to this, `tidy.manova` would return a column named `pillai` no
matter the test specified by the user. Now the column that gets
returned has different names depending on the particular test selected
by the user.