### PR TITLE
Support PCA (prcomp)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
     person("Luke", "Johnston", email = "luke.johnston@mail.utoronto.ca", role = "ctb"),
     person("Ben", "Bolker", email = "bolker@mcmaster.ca", role = "ctb"),
     person("Francois", "Briatte", email = "f.briatte@gmail.com", role = "ctb"),
-    person("Hadley", "Wickham", email = "hadley@rstudio.com", role = "ctb")
+    person("Hadley", "Wickham", email = "hadley@rstudio.com", role = "ctb"),
+    person("Masaaki", "Horikoshi", email = "sinhrks@gmail.com", role = "ctb")
     )
 Maintainer: David Robinson <admiral.david@gmail.com>
 Description: Convert statistical analysis objects from R into tidy data frames,

--- a/R/pca_tidiers.R
+++ b/R/pca_tidiers.R
@@ -1,0 +1,71 @@
+#' Tidying methods for PCA objects
+#' 
+#' These methods summarize the results of principal component analysis into three
+#' tidy forms. \code{tidy} describes the principal components,
+#' \code{augment} adds the principal component scores to the original data, and
+#' \code{glance} summarizes the standard deviation and propotions.
+#'
+#' @param x prcomp object
+#' @param data Original data (required for \code{augment})
+#' @param ... extra arguments, not used
+#'
+#' @return All tidying methods return a \code{data.frame} without rownames.
+#' The structure depends on the method chosen.
+#'
+#' @seealso \code{\link{prcomp}}
+#'
+#' @examples
+#' 
+#' library(dplyr)
+#' library(ggplot2)
+#' 
+#' pca <- prcomp(iris[-5])
+#' tidy(pca)
+#' head(augment(pca, iris[-5]))
+#' glance(pca)
+#' 
+#' @name pca_tidiers
+#' 
+NULL
+
+
+#' @rdname pca_tidiers
+#' 
+#' @return \code{tidy} returns principal components
+#' 
+#' @export
+tidy.prcomp <- function(x, ...) {
+    ret <- as.data.frame(x$rotation)
+    fix_data_frame(ret, newcol = ".rownames")
+}
+
+
+#' @rdname pca_tidiers
+#' 
+#' @return \code{augment} returns the original data with principal component scores
+#' 
+#' @export
+augment.prcomp <- function(x, data, ...) {
+    # move rownames if necessary
+    data <- fix_data_frame(data, newcol = ".rownames")
+    components <- as.data.frame(x$x)
+    cbind(as.data.frame(data), components)
+}
+
+
+#' @rdname pca_tidiers
+#' 
+#' @return \code{glance} returns a one-row data.frame with the columns
+#'   \item{Standard deviation}
+#'   \item{Proportion of Variance}
+#'   \item{Cumulative Proportion}
+#' 
+#' @export
+glance.prcomp <- function(x, ...) {
+    vars <- x$sdev^2
+    vars <- vars / sum(vars)
+    ret <- data.frame(c1 = colnames(x$x), c2 = x$sdev, c3 = vars, c4 = cumsum(vars),
+                      stringsAsFactors = FALSE)
+    colnames(ret) = c('.rownames', 'Standard deviation', 'Proportion of Variance', 'Cumulative Proportion')
+    ret
+}

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ lmfit
 ```
 
 ```
-## 
+##
 ## Call:
 ## lm(formula = mpg ~ wt, data = mtcars)
-## 
+##
 ## Coefficients:
-## (Intercept)           wt  
+## (Intercept)           wt
 ##      37.285       -5.344
 ```
 
@@ -69,23 +69,23 @@ summary(lmfit)
 ```
 
 ```
-## 
+##
 ## Call:
 ## lm(formula = mpg ~ wt, data = mtcars)
-## 
+##
 ## Residuals:
-##     Min      1Q  Median      3Q     Max 
-## -4.5432 -2.3647 -0.1252  1.4096  6.8727 
-## 
+##     Min      1Q  Median      3Q     Max
+## -4.5432 -2.3647 -0.1252  1.4096  6.8727
+##
 ## Coefficients:
-##             Estimate Std. Error t value Pr(>|t|)    
+##             Estimate Std. Error t value Pr(>|t|)
 ## (Intercept)  37.2851     1.8776  19.858  < 2e-16 ***
 ## wt           -5.3445     0.5591  -9.559 1.29e-10 ***
 ## ---
 ## Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
-## 
+##
 ## Residual standard error: 3.046 on 30 degrees of freedom
-## Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446 
+## Multiple R-squared:  0.7528,	Adjusted R-squared:  0.7446
 ## F-statistic: 91.38 on 1 and 30 DF,  p-value: 1.294e-10
 ```
 
@@ -395,6 +395,7 @@ A full list of the `tidy`, `augment` and `glance` methods available for each cla
 |Polygon                  |x      |         |          |
 |Polygons                 |x      |         |          |
 |power.htest              |x      |         |          |
+|prcomp                   |x      |x        |x         |
 |pyears                   |x      |x        |          |
 |ridgelm                  |x      |x        |          |
 |roc                      |x      |         |          |

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -1,0 +1,29 @@
+# test tidy, augment, glance from pca objects
+
+context("pca tidiers")
+
+test_that("tidy.prcomp works", {
+    pca <- prcomp(iris[-5])
+    
+    td <- tidy(pca)
+    exp <- data.frame(`.rownames` = c('Sepal.Length', 'Sepal.Width', 'Petal.Length', 'Petal.Width'),
+                      PC1 = c(0.36138659, -0.08452251, 0.85667061, 0.35828920),
+                      PC2 = c(-0.65658877, -0.73016143, 0.17337266, 0.07548102),
+                      PC3 = c(0.58202985, -0.59791083, -0.07623608, -0.54583143),
+                      PC4 = c(0.3154872, -0.3197231, -0.4798390, 0.7536574),
+                      stringsAsFactors = FALSE)
+    expect_equal(td, exp, tolerance=1e-5)
+    
+    aug <- augment(pca, iris[-5])
+    expect_equal(colnames(aug), c('Sepal.Length', 'Sepal.Width', 'Petal.Length', 'Petal.Width',
+                                  'PC1', 'PC2', 'PC3', 'PC4'))
+    
+    gl <- glance(pca)
+    exp <- data.frame(c('PC1', 'PC2', 'PC3', 'PC4'),
+                      c(2.0562689, 0.4926162, 0.2796596, 0.1543862),
+                      c(0.924618723, 0.053066483, 0.017102610, 0.005212184),
+                      c(0.9246187, 0.9776852, 0.9947878, 1.0000000), 
+                      stringsAsFactors = FALSE)
+    colnames(exp) <- c('.rownames', 'Standard deviation', 'Proportion of Variance', 'Cumulative Proportion')
+    expect_equal(gl, exp, tolerance=1e-5)
+})


### PR DESCRIPTION
Added PCA tidiers.

```
tidy(prcomp(iris[-5]))
#      .rownames         PC1         PC2         PC3        PC4
# 1 Sepal.Length  0.36138659 -0.65658877  0.58202985  0.3154872
# 2  Sepal.Width -0.08452251 -0.73016143 -0.59791083 -0.3197231
# 3 Petal.Length  0.85667061  0.17337266 -0.07623608 -0.4798390
# 4  Petal.Width  0.35828920  0.07548102 -0.54583143  0.7536574

head(augment(prcomp(iris[-5]), iris[-5]))
#   Sepal.Length Sepal.Width Petal.Length Petal.Width       PC1        PC2         PC3          PC4
# 1          5.1         3.5          1.4         0.2 -2.684126 -0.3193972  0.02791483  0.002262437
# 2          4.9         3.0          1.4         0.2 -2.714142  0.1770012  0.21046427  0.099026550
# 3          4.7         3.2          1.3         0.2 -2.888991  0.1449494 -0.01790026  0.019968390
# 4          4.6         3.1          1.5         0.2 -2.745343  0.3182990 -0.03155937 -0.075575817
# 5          5.0         3.6          1.4         0.2 -2.728717 -0.3267545 -0.09007924 -0.061258593
# 6          5.4         3.9          1.7         0.4 -2.280860 -0.7413304 -0.16867766 -0.024200858

glance(prcomp(iris[-5]))
#   .rownames Standard deviation Proportion of Variance Cumulative Proportion
# 1       PC1          2.0562689            0.924618723             0.9246187
# 2       PC2          0.4926162            0.053066483             0.9776852
# 3       PC3          0.2796596            0.017102610             0.9947878
# 4       PC4          0.1543862            0.005212184             1.0000000
```