### PR TITLE
More rstan support

### DIFF
--- a/R/mcmc_tidiers.R
+++ b/R/mcmc_tidiers.R
@@ -1,7 +1,7 @@
 #' Tidying methods for MCMC (Stan, JAGS, etc.) fits
 #'
 #' @param x an object of class \sQuote{"stanfit"}
-#' @param pars (character) specification of which parameters to nclude
+#' @param pars (character) specification of which parameters to include
 #' @param estimate.method method for computing point estimate ("mean" or median")
 #' @param conf.int (logical) include confidence interval?
 #' @param conf.level probability level for CI
@@ -65,9 +65,10 @@ tidyMCMC <- function(x,
                      conf.method = "quantile",
                      droppars = "lp__",
                      ...) {
-    ss <- as.matrix(x)  ## works natively on stanfit, mcmc.list, mcmc objects
+    stan <- is(x, "stanfit")
+    ss <- if (stan) as.matrix(x, pars = pars) else as.matrix(x)
     ss <- ss[, !colnames(ss) %in% droppars]  ## drop log-probability info
-    if (!missing(pars)) {
+    if (!missing(pars) && !stan) {
         if (length(badpars <- which(!pars %in% colnames(ss))) > 0) {
             stop("unrecognized parameters: ", pars[badpars])
         }

--- a/R/mcmc_tidiers.R
+++ b/R/mcmc_tidiers.R
@@ -70,7 +70,7 @@ tidyMCMC <- function(x,
                      ...) {
     stan <- is(x, "stanfit")
     ss <- if (stan) as.matrix(x, pars = pars) else as.matrix(x)
-    ss <- ss[, !colnames(ss) %in% droppars]  ## drop log-probability info
+    ss <- ss[, !colnames(ss) %in% droppars, drop = FALSE]  ## drop log-probability info
     if (!missing(pars) && !stan) {
         if (length(badpars <- which(!pars %in% colnames(ss))) > 0) {
             stop("unrecognized parameters: ", pars[badpars])

--- a/R/mcmc_tidiers.R
+++ b/R/mcmc_tidiers.R
@@ -41,7 +41,7 @@
 #'   load(infile)
 #'   
 #'   tidy(rstan_example)
-#'   tidy(rstan_example, conf.int = TRUE)
+#'   tidy(rstan_example, conf.int = TRUE, pars = "theta")
 #'   
 #'   td_mean <- tidy(rstan_example, conf.int = TRUE)
 #'   td_median <- tidy(rstan_example, conf.int = TRUE, estimate.method = "median")

--- a/R/mcmc_tidiers.R
+++ b/R/mcmc_tidiers.R
@@ -99,8 +99,8 @@ tidyMCMC <- function(x,
     
     if (rhat || ess) {
         if (!stan) warning("ignoring 'rhat' and 'ess' (only available for stanfit objects)")
-        summ <- rstan::summary(x, pars = pars, probs = NULL)$summary[, c("Rhat", "n_eff")]
-        summ <- summ[!dimnames(summ)[[1L]] %in% droppars, ]
+        summ <- rstan::summary(x, pars = pars, probs = NULL)$summary[, c("Rhat", "n_eff"), drop = FALSE]
+        summ <- summ[!dimnames(summ)[[1L]] %in% droppars,, drop = FALSE]
         if (rhat) ret$rhat <- summ[, "Rhat"]
         if (ess) ret$ess <- as.integer(round(summ[, "n_eff"]))
     }


### PR DESCRIPTION
This pull request fixes a small bug and adds adds a few useful features for stanfit objects:

* Fix bug where a dimension error was thrown when dropping `droppars` if only one parameter was selected by the user.

* Make it easier to select parameters by making use of the `pars` argument to the `as.matrix` method for stanfit objects, which allows selecting vectors/matrices/arrays of parameters by group. 

* Add `rhat` and `ess` arguments (both defaulting to `FALSE`) to toggle the inclusion of Rhat and effective sample size estimates. 
