### PR TITLE
Grouped bootstrap

### DIFF
--- a/R/extras.R
+++ b/R/extras.R
@@ -5,6 +5,8 @@
 #'
 #' @param df a data frame
 #' @param m number of bootstrap replicates to perform
+#' @param by_group If \code{TRUE}, then bootstrap within each group if \code{df} is
+#'    a grouped tbl. 
 #'
 #' @details This code originates from Hadley Wickham (with a few small
 #' corrections) here:
@@ -21,17 +23,26 @@
 #' mtcars %>% bootstrap(10) %>% do(tidy(lm(mpg ~ wt, .)))
 #' 
 #' @export
-bootstrap <- function(df, m) {
+bootstrap <- function (df, m, by_group = FALSE)  {
     n <- nrow(df)
-    
-    attr(df, "indices") <- replicate(m, sample(n, replace = TRUE) - 1,
-                                     simplify = FALSE)
+    attr(df, "indices") <-
+        if (by_group && !is.null(groups(df))) {
+            replicate(m, 
+                      unlist(lapply(attr(df, "indices"), 
+                                    function(x) {
+                                        sample(x, replace = TRUE)
+                                    }),
+                             recursive = FALSE, use.names = FALSE),
+                      simplify = FALSE)
+        } else {
+            replicate(m, sample(n, replace = TRUE) - 
+                          1, simplify = FALSE)
+        }
     attr(df, "drop") <- TRUE
     attr(df, "group_sizes") <- rep(n, m)
     attr(df, "biggest_group_size") <- n
     attr(df, "labels") <- data.frame(replicate = 1:m)
     attr(df, "vars") <- list(quote(replicate))
     class(df) <- c("grouped_df", "tbl_df", "tbl", "data.frame")
-    
     df
 }

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -1,0 +1,40 @@
+context("bootstrapping")
+library("dplyr")
+
+test_that("bootstrap works with by_group and grouped tbl", {
+    df <- data_frame(x = c(rep("a", 3), rep("b", 5)),
+                    y = rnorm(length(x)))
+    df_reps <-
+        df %>%
+        group_by(x) %>%
+        bootstrap(20, by_group = TRUE) %>%
+        do(tally(group_by(., x)))
+    expect_true(all(filter(df_reps, x == "a")$n == 3))
+    expect_true(all(filter(df_reps, x == "b")$n == 5))                  
+})
+
+test_that("bootstrap does not sample within groups if by_group = FALSE", {
+    set.seed(12334)
+    df <- data_frame(x = c(rep("a", 3), rep("b", 5)),
+                     y = rnorm(length(x)))
+    df_reps <-
+        df %>%
+        group_by(x) %>%
+        bootstrap(20, by_group = FALSE) %>%
+        do(tally(group_by(., x)))
+    expect_true(!all(filter(df_reps, x == "a")$n == 3))
+    expect_true(!all(filter(df_reps, x == "b")$n == 5))                  
+})
+
+test_that("bootstrap does not sample within groups if no groups", {
+    set.seed(12334)
+    df <- data_frame(x = c(rep("a", 3), rep("b", 5)),
+                     y = rnorm(length(x)))
+    df_reps <-
+        df %>%
+        ungroup() %>%
+        bootstrap(20, by_group = TRUE) %>%
+        do(tally(group_by(., x)))
+    expect_true(!all(filter(df_reps, x == "a")$n == 3))
+    expect_true(!all(filter(df_reps, x == "b")$n == 5))                  
+})

--- a/vignettes/bootstrapping.Rmd
+++ b/vignettes/bootstrapping.Rmd
@@ -33,25 +33,8 @@ ggplot(mtcars, aes(wt, mpg)) + geom_point() + geom_line(aes(y=predict(nlsfit)))
 ```
 
 While this does provide a p-value and confidence intervals for the parameters, these are based on model assumptions that may not hold in real data. Bootstrapping is a popular method for providing confidence intervals and predictions that are more robust to the nature of the data.
-
-First, we construct 100 bootstrap replications of the data, each of which has been randomly sampled with replacement. Hadley provides a bootstrap grouping function [here](https://github.com/hadley/dplyr/issues/269):
-
-```{r}
-bootstrap <- function(df, m) {
-  n <- nrow(df)
-
-  attr(df, "indices") <- replicate(m, sample(n, replace = TRUE) - 1, 
-                                   simplify = FALSE)
-  attr(df, "drop") <- TRUE
-  attr(df, "group_sizes") <- rep(n, m)
-  attr(df, "biggest_group_size") <- n
-  attr(df, "labels") <- data.frame(replicate = 1:m)
-  attr(df, "vars") <- list(quote(replicate))
-  class(df) <- c("grouped_df", "tbl_df", "tbl", "data.frame")
-
-  df
-}
-```
+The function `bootstrap` in **broom** can be used to sample bootstrap replications.
+First, we construct 100 bootstrap replications of the data, each of which has been randomly sampled with replacement. 
 
 We use `do` to perform an `nls` fit on each replication, using `tidy` to recombine:
 


### PR DESCRIPTION
This PR adds an argument, `by_groups`, to `bootstrap` which if `TRUE` and the tbl has groups, will use the groups as strata when bootstrapping. 

- added this functionality to `bootstrap`
- added tests for `bootstrap`
- updated bootstrap vignette to reference the `bootstrap` function in **broom** instead including the source of the function within the vignette.