### PR TITLE
fix bug in tidy.glmnet

### DIFF
--- a/R/glmnet_tidiers.R
+++ b/R/glmnet_tidiers.R
@@ -77,7 +77,7 @@ tidy.glmnet <- function(x, ...) {
         }, .id = "class")
         ret <- beta_d %>% tidyr::gather(step, estimate, -term, -class)
     } else {
-        beta_d <- fix_data_frame(as.matrix(beta), newcol = "term")
+        beta_d <- fix_data_frame(as.matrix(beta), newnames=1:ncol(beta), newcol = "term")
         ret <- beta_d %>% tidyr::gather(step, estimate, -term)
     }
     # add values specific to each step


### PR DESCRIPTION
Colnames in beta (from stats:coef function) contain non-numeric characters. As a result, the function as.numeric() generates NAs and lambda, dev.ratio are not populated correctly.