### PR TITLE
Cache package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Sample .travis.yml for R projects
 
 language: r
-warnings_are_errors: true
-sudo: required
+sudo: false
+cache: packages
 after_success:
   - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
This will use package dependency caching on Travis, which should speed up your builds once the cache is populated.

I am glad your talk got moved to the bigger room, but sorry I missed it as a consequence :(