### PR TITLE
Fix bug in the output of the xyz list tidier

### DIFF
--- a/R/list-xyz-tidiers.R
+++ b/R/list-xyz-tidiers.R
@@ -39,9 +39,9 @@ tidy_xyz <- function(x, ...) {
     )
   }
   
-  d <- as_tibble(x$z)
-  names(d) <- x$y
-  d$x <- x$x
-  tidyr::gather(d, y, z, -x)
-
+  as_tibble(data.frame(
+    x=x$x,
+    y=rep(x$y, each=length(x$x)),
+    z=as.numeric(x$z)
+  ))
 }

--- a/tests/testthat/test-list-xyz.R
+++ b/tests/testthat/test-list-xyz.R
@@ -34,6 +34,10 @@ test_that("tidy_xyz", {
   check_tidy_output(td, strict = FALSE)
   check_dims(td, 15, 3)
   
+  expect_true(is.numeric(td$x))
+  expect_true(is.numeric(td$y))
+  expect_true(is.numeric(td$z))
+  
   expect_error(
     tidy(b),
     regexp = paste(


### PR DESCRIPTION
Use a simpler code that avoids gather() and the change in the type of the
y column that it brought.
Add tests to make sure the nature of the columns stays numeric in the future.